### PR TITLE
Add LibGDX RPG skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+**/build/
+*.iml
+.idea/
+*.png

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # rpg
+
+Sample LibGDX-based 2D RPG project skeleton with Kotlin. Includes basic movement, stats, and inventory systems.

--- a/android/src/main/kotlin/com/example/mmorpg/AndroidLauncher.kt
+++ b/android/src/main/kotlin/com/example/mmorpg/AndroidLauncher.kt
@@ -1,0 +1,13 @@
+package com.example.mmorpg
+
+import android.os.Bundle
+import com.badlogic.gdx.backends.android.AndroidApplication
+import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
+
+class AndroidLauncher : AndroidApplication() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val config = AndroidApplicationConfiguration()
+        initialize(MyGame(), config)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,39 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
+    }
+}
+
+ext {
+    gdxVersion = '1.12.1'
+}
+
+subprojects {
+    repositories {
+        mavenCentral()
+    }
+}
+
+project(':core') {
+    apply plugin: 'org.jetbrains.kotlin.jvm'
+    dependencies {
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.22"
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
+    }
+    compileKotlin.kotlinOptions.jvmTarget = '1.8'
+    compileTestKotlin.kotlinOptions.jvmTarget = '1.8'
+}
+
+project(':desktop') {
+    apply plugin: 'org.jetbrains.kotlin.jvm'
+    dependencies {
+        implementation project(':core')
+        implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+    }
+    compileKotlin.kotlinOptions.jvmTarget = '1.8'
+    compileTestKotlin.kotlinOptions.jvmTarget = '1.8'
+}

--- a/core/src/main/kotlin/com/example/mmorpg/MyGame.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/MyGame.kt
@@ -1,0 +1,10 @@
+package com.example.mmorpg
+
+import com.badlogic.gdx.Game
+import com.example.mmorpg.screens.GameScreen
+
+class MyGame : Game() {
+    override fun create() {
+        setScreen(GameScreen())
+    }
+}

--- a/core/src/main/kotlin/com/example/mmorpg/entities/Entity.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/entities/Entity.kt
@@ -1,0 +1,18 @@
+package com.example.mmorpg.entities
+
+import com.badlogic.gdx.graphics.Texture
+import com.badlogic.gdx.graphics.g2d.SpriteBatch
+import com.badlogic.gdx.math.Vector2
+
+open class Entity(
+    var position: Vector2 = Vector2(0f, 0f),
+    val texture: Texture
+) {
+    open fun update(delta: Float) {
+        // Common update logic
+    }
+
+    open fun render(batch: SpriteBatch) {
+        batch.draw(texture, position.x, position.y)
+    }
+}

--- a/core/src/main/kotlin/com/example/mmorpg/entities/Player.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/entities/Player.kt
@@ -1,0 +1,53 @@
+package com.example.mmorpg.entities
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.Pixmap
+import com.badlogic.gdx.graphics.Texture
+import com.badlogic.gdx.graphics.g2d.SpriteBatch
+import com.badlogic.gdx.math.Vector2
+import com.example.mmorpg.systems.Inventory
+import com.example.mmorpg.systems.Stats
+import com.example.mmorpg.utils.Constants
+
+class Player(position: Vector2 = Vector2(50f, 50f)) : Entity(position, createTexture()) {
+
+    var stats = Stats(
+        level = 1,
+        maxHp = 100,
+        hp = 100,
+        maxMp = 30,
+        mp = 30,
+        exp = 0
+    )
+    val inventory = Inventory()
+    private val speed = 100f
+
+    override fun update(delta: Float) {
+        handleInput(delta)
+    }
+
+    private fun handleInput(delta: Float) {
+        val move = Vector2()
+        if (Gdx.input.isKeyPressed(Constants.KEY_UP)) move.y += speed
+        if (Gdx.input.isKeyPressed(Constants.KEY_DOWN)) move.y -= speed
+        if (Gdx.input.isKeyPressed(Constants.KEY_LEFT)) move.x -= speed
+        if (Gdx.input.isKeyPressed(Constants.KEY_RIGHT)) move.x += speed
+        position.add(move.scl(delta))
+    }
+
+    fun renderUI(batch: SpriteBatch) {
+        // Draw HP, MP, level etc. using BitmapFont in a real game
+    }
+
+    companion object {
+        private fun createTexture(): Texture {
+            val pixmap = Pixmap(16, 16, Pixmap.Format.RGBA8888)
+            pixmap.setColor(Color.BLUE)
+            pixmap.fill()
+            val texture = Texture(pixmap)
+            pixmap.dispose()
+            return texture
+        }
+    }
+}

--- a/core/src/main/kotlin/com/example/mmorpg/screens/GameScreen.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/screens/GameScreen.kt
@@ -1,0 +1,25 @@
+package com.example.mmorpg.screens
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.ScreenAdapter
+import com.badlogic.gdx.graphics.GL20
+import com.badlogic.gdx.graphics.g2d.SpriteBatch
+import com.example.mmorpg.entities.Player
+
+class GameScreen : ScreenAdapter() {
+    private val batch = SpriteBatch()
+    private val player = Player()
+
+    override fun render(delta: Float) {
+        player.update(delta)
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
+        batch.begin()
+        player.render(batch)
+        player.renderUI(batch)
+        batch.end()
+    }
+
+    override fun dispose() {
+        batch.dispose()
+    }
+}

--- a/core/src/main/kotlin/com/example/mmorpg/systems/Inventory.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/systems/Inventory.kt
@@ -1,0 +1,13 @@
+package com.example.mmorpg.systems
+
+class Inventory {
+    private val items = mutableListOf<String>()
+
+    fun addItem(item: String) {
+        items.add(item)
+    }
+
+    fun removeItem(item: String): Boolean = items.remove(item)
+
+    fun listItems(): List<String> = items.toList()
+}

--- a/core/src/main/kotlin/com/example/mmorpg/systems/Stats.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/systems/Stats.kt
@@ -1,0 +1,28 @@
+package com.example.mmorpg.systems
+
+data class Stats(
+    var level: Int,
+    var maxHp: Int,
+    var hp: Int,
+    var maxMp: Int,
+    var mp: Int,
+    var exp: Int
+) {
+    fun addExp(amount: Int) {
+        exp += amount
+        while (exp >= requiredExpForNextLevel()) {
+            exp -= requiredExpForNextLevel()
+            levelUp()
+        }
+    }
+
+    private fun levelUp() {
+        level++
+        maxHp += 10
+        maxMp += 5
+        hp = maxHp
+        mp = maxMp
+    }
+
+    private fun requiredExpForNextLevel(): Int = level * 100
+}

--- a/core/src/main/kotlin/com/example/mmorpg/utils/Constants.kt
+++ b/core/src/main/kotlin/com/example/mmorpg/utils/Constants.kt
@@ -1,0 +1,10 @@
+package com.example.mmorpg.utils
+
+import com.badlogic.gdx.Input
+
+object Constants {
+    const val KEY_UP = Input.Keys.W
+    const val KEY_DOWN = Input.Keys.S
+    const val KEY_LEFT = Input.Keys.A
+    const val KEY_RIGHT = Input.Keys.D
+}

--- a/desktop/src/main/kotlin/com/example/mmorpg/desktop/DesktopLauncher.kt
+++ b/desktop/src/main/kotlin/com/example/mmorpg/desktop/DesktopLauncher.kt
@@ -1,0 +1,16 @@
+package com.example.mmorpg.desktop
+
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
+import com.example.mmorpg.MyGame
+
+object DesktopLauncher {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val config = Lwjgl3ApplicationConfiguration().apply {
+            setTitle("MMORPG")
+            setWindowedMode(800, 600)
+        }
+        Lwjgl3Application(MyGame(), config)
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'rpg'
+include 'core', 'desktop'


### PR DESCRIPTION
## Summary
- configure Kotlin Gradle plugin via buildscript for reliable resolution
- procedurally generate player texture to avoid committing binary assets
- ignore PNG assets to prevent binary files from blocking pushes
- remove committed player PNG asset

## Testing
- `gradle build` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898ee5c23008332a46a6f25c5bdd4cd