### PR TITLE
Add non-curses text mode for grid movement demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ This is a simple text-based grid movement demo similar to RPG Maker movement.
 
 ## Controls
 
-- Arrow keys: Move the `@` character up, down, left, or right within the grid.
+- Arrow keys: Move the `@` character up, down, left, or right within the grid (when running in a real terminal).
+- `W`, `A`, `S`, `D`: Move up, left, down, or right when running in the fallback text mode.
 - `q`: Quit the game.
 
 ## Running
 
-The game uses Python's built-in `curses` module. Run it from a terminal:
+Run the script with Python:
 
 ```bash
 python main.py
 ```
+
+The game will try to use Python's built-in `curses` module for an arrow-key interface. If the terminal doesn't support curses (for example, when running in certain IDEs or non-interactive environments), the script automatically falls back to a simple text mode using the `WASD` controls.

--- a/main.py
+++ b/main.py
@@ -1,10 +1,21 @@
+"""Simple grid movement game with terminal fallback.
+
+This module attempts to run a small grid‑based movement demo using the
+``curses`` library for arrow‑key input. If the program is executed in an
+environment that doesn't support curses (for example, when stdin/stdout is
+not a TTY), it falls back to a plain text mode controlled with ``WASD``
+commands.
+"""
+
 import curses
+import sys
 
 GRID_WIDTH = 10
 GRID_HEIGHT = 10
 
 
-def main(stdscr):
+def run_curses(stdscr):
+    """Play the game using the curses interface."""
     curses.curs_set(0)
     stdscr.nodelay(False)
     stdscr.keypad(True)
@@ -33,5 +44,41 @@ def main(stdscr):
             player_x += 1
 
 
+def run_text():
+    """Fallback text mode controlled with WASD keys."""
+    player_x = GRID_WIDTH // 2
+    player_y = GRID_HEIGHT // 2
+
+    while True:
+        # Clear the screen for a simple animation effect. Using ANSI escape
+        # codes avoids relying on external commands like ``clear`` which may
+        # be unavailable in restricted environments.
+        print("\033[H\033[J", end="")
+        for y in range(GRID_HEIGHT):
+            row = ''.join(
+                '@' if (x, y) == (player_x, player_y) else '.'
+                for x in range(GRID_WIDTH)
+            )
+            print(row)
+
+        command = input("Move with WASD or q to quit: ").strip().lower()
+        if command == 'q':
+            break
+        elif command == 'w' and player_y > 0:
+            player_y -= 1
+        elif command == 's' and player_y < GRID_HEIGHT - 1:
+            player_y += 1
+        elif command == 'a' and player_x > 0:
+            player_x -= 1
+        elif command == 'd' and player_x < GRID_WIDTH - 1:
+            player_x += 1
+
+
 if __name__ == "__main__":
-    curses.wrapper(main)
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        try:
+            curses.wrapper(run_curses)
+        except curses.error:
+            run_text()
+    else:
+        run_text()


### PR DESCRIPTION
## Summary
- Add fallback text mode so the grid movement demo can run without a TTY or curses
- Document WASD controls and automatic fallback in README

## Testing
- `python main.py <<'EOF' >/tmp/out.txt
q
EOF`
- `cat -v /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_689a9ba7d54c833298aa591443a38b50