### PR TITLE
Add HTML demo with scrolling background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,70 +1,85 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <title>Grid Movement Game</title>
+  <meta charset="utf-8">
+  <title>Scrolling Background Demo</title>
   <style>
-    body {
-      font-family: monospace;
-    }
-    #grid {
-      font-size: 20px;
-      line-height: 1.2;
-    }
+    body { margin: 0; overflow: hidden; }
+    #game { display: block; background: #000; }
   </style>
 </head>
 <body>
-<pre id="grid"></pre>
+<canvas id="game" width="400" height="300"></canvas>
 <script>
-const WIDTH = 10;
-const HEIGHT = 10;
-let playerX = Math.floor(WIDTH / 2);
-let playerY = Math.floor(HEIGHT / 2);
-const gridEl = document.getElementById('grid');
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
 
-function draw() {
-  const lines = [];
-  for (let y = 0; y < HEIGHT; y++) {
-    let line = '';
-    for (let x = 0; x < WIDTH; x++) {
-      line += (x === playerX && y === playerY) ? '@' : '.';
-    }
-    lines.push(line);
-  }
-  gridEl.textContent = lines.join('\n');
+// Build a repeating background
+const bgCanvas = document.createElement('canvas');
+bgCanvas.width = canvas.width * 2;
+bgCanvas.height = canvas.height;
+const bgCtx = bgCanvas.getContext('2d');
+
+// Sky gradient
+const grad = bgCtx.createLinearGradient(0, 0, 0, bgCanvas.height);
+grad.addColorStop(0, '#87CEEB');
+grad.addColorStop(1, '#FFFFFF');
+bgCtx.fillStyle = grad;
+bgCtx.fillRect(0, 0, bgCanvas.width, bgCanvas.height);
+
+// Ground stripes
+for (let i = 0; i < bgCanvas.width / 20; i++) {
+  bgCtx.fillStyle = i % 2 ? '#228B22' : '#32CD32';
+  bgCtx.fillRect(i * 20, bgCanvas.height - 50, 20, 50);
 }
 
-draw();
+let bgX = 0;
 
-function move(dx, dy) {
-  playerX = Math.min(WIDTH - 1, Math.max(0, playerX + dx));
-  playerY = Math.min(HEIGHT - 1, Math.max(0, playerY + dy));
-  draw();
+// Player data
+const player = { x: 50, y: canvas.height - 70, w: 20, h: 20, speed: 4 };
+
+function loop() {
+  bgX -= 2;
+  if (bgX <= -canvas.width) bgX = 0;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(bgCanvas, bgX, 0);
+  ctx.drawImage(bgCanvas, bgX + bgCanvas.width / 2, 0);
+
+  ctx.fillStyle = 'red';
+  ctx.fillRect(player.x, player.y, player.w, player.h);
+
+  requestAnimationFrame(loop);
 }
+requestAnimationFrame(loop);
 
 document.addEventListener('keydown', (e) => {
   switch (e.key) {
     case 'ArrowUp':
     case 'w':
     case 'W':
-      move(0, -1);
+      player.y -= player.speed;
       break;
     case 'ArrowDown':
     case 's':
     case 'S':
-      move(0, 1);
+      player.y += player.speed;
       break;
     case 'ArrowLeft':
     case 'a':
     case 'A':
-      move(-1, 0);
+      player.x -= player.speed;
       break;
     case 'ArrowRight':
     case 'd':
     case 'D':
-      move(1, 0);
+      player.x += player.speed;
       break;
   }
+
+  // Constrain player to canvas
+  player.x = Math.max(0, Math.min(canvas.width - player.w, player.x));
+  player.y = Math.max(0, Math.min(canvas.height - player.h, player.y));
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Replace simple grid with canvas-based game
- Implement auto-scrolling background and arrow-key player movement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c2c4c78833292b2a05c8931a76d