### PR TITLE
Add canvas-based test NPC sprite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains simple movement demos implemented with HTML5 and JavaSc
 
 - Open `index.html` in a modern web browser to try the pseudo-3D canvas demo.
 - The `android-webview` folder includes an example HTML page for touch input and a `MainActivity.kt` that loads it in an Android WebView.
+- A test NPC is rendered using a canvas-based sprite to demonstrate image-style characters without external files.
 
 ## Controls
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,38 @@
   player.position.set(0, 0.5, 0);
   scene.add(player);
 
+  // Test NPC rendered from a canvas texture
+  function createNPC() {
+    const size = 64;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+
+    // Face background
+    ctx.fillStyle = '#ffffaa';
+    ctx.fillRect(0, 0, size, size);
+
+    // Eyes
+    ctx.fillStyle = '#000000';
+    ctx.fillRect(16, 20, 8, 8);
+    ctx.fillRect(40, 20, 8, 8);
+
+    // Mouth
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(24, 40, 16, 8);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+    const sprite = new THREE.Sprite(material);
+    sprite.position.set(5, 0.5, 5);
+    sprite.scale.set(2, 2, 1);
+    return sprite;
+  }
+
+  const npc = createNPC();
+  scene.add(npc);
+
   camera.position.set(0, 10, 20);
   camera.lookAt(player.position);
 


### PR DESCRIPTION
## Summary
- Render a test NPC on the map using a canvas-based sprite so it appears image-like without external files
- Document NPC addition in the README

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9cf250888332a4a11d136bd8ce5d