### PR TITLE
Add chibi player with walking motion

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,46 @@
   const grid = new THREE.GridHelper(200, 20, 0x444444, 0x88cc88);
   scene.add(grid);
 
-  // Player cube
-  const geometry = new THREE.BoxGeometry(1, 1, 1);
-  const material = new THREE.MeshBasicMaterial({ color: 0xff0000 });
-  const player = new THREE.Mesh(geometry, material);
+  // Player character (2-head chibi)
+  function createPlayer() {
+    const group = new THREE.Group();
+
+    const bodyMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+    const headMaterial = new THREE.MeshBasicMaterial({ color: 0xffccaa });
+    const limbMaterial = new THREE.MeshBasicMaterial({ color: 0x0000ff });
+
+    const body = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.6, 0.3), bodyMaterial);
+    body.position.y = 0.3;
+    group.add(body);
+
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.3, 32, 32), headMaterial);
+    head.position.y = 0.9;
+    group.add(head);
+
+    function createLimb(width, height, material) {
+      const limb = new THREE.Group();
+      const geom = new THREE.BoxGeometry(width, height, width);
+      const mesh = new THREE.Mesh(geom, material);
+      mesh.position.y = -height / 2;
+      limb.add(mesh);
+      return limb;
+    }
+
+    const leftArm = createLimb(0.15, 0.4, limbMaterial);
+    leftArm.position.set(-0.45, 0.6, 0);
+    const rightArm = createLimb(0.15, 0.4, limbMaterial);
+    rightArm.position.set(0.45, 0.6, 0);
+    const leftLeg = createLimb(0.15, 0.5, limbMaterial);
+    leftLeg.position.set(-0.2, 0, 0);
+    const rightLeg = createLimb(0.15, 0.5, limbMaterial);
+    rightLeg.position.set(0.2, 0, 0);
+
+    group.add(leftArm, rightArm, leftLeg, rightLeg);
+    group.userData = { leftArm, rightArm, leftLeg, rightLeg };
+    return group;
+  }
+
+  const player = createPlayer();
   player.position.set(0, 0.5, 0);
   scene.add(player);
 
@@ -70,11 +106,32 @@
   document.addEventListener('keydown', (e) => { keys[e.key.toLowerCase()] = true; });
   document.addEventListener('keyup', (e) => { keys[e.key.toLowerCase()] = false; });
 
+  let walkOffset = 0;
+
   function update() {
-    if (keys['w'] || keys['arrowup']) player.position.z -= speed;
-    if (keys['s'] || keys['arrowdown']) player.position.z += speed;
-    if (keys['a'] || keys['arrowleft']) player.position.x -= speed;
-    if (keys['d'] || keys['arrowright']) player.position.x += speed;
+    const moving = keys['w'] || keys['arrowup'] ||
+                   keys['s'] || keys['arrowdown'] ||
+                   keys['a'] || keys['arrowleft'] ||
+                   keys['d'] || keys['arrowright'];
+
+    if (moving) {
+      if (keys['w'] || keys['arrowup']) player.position.z -= speed;
+      if (keys['s'] || keys['arrowdown']) player.position.z += speed;
+      if (keys['a'] || keys['arrowleft']) player.position.x -= speed;
+      if (keys['d'] || keys['arrowright']) player.position.x += speed;
+
+      walkOffset += 0.2;
+      const angle = Math.sin(walkOffset) * 0.5;
+      player.userData.leftLeg.rotation.x = angle;
+      player.userData.rightLeg.rotation.x = -angle;
+      player.userData.leftArm.rotation.x = -angle;
+      player.userData.rightArm.rotation.x = angle;
+    } else {
+      player.userData.leftLeg.rotation.x = 0;
+      player.userData.rightLeg.rotation.x = 0;
+      player.userData.leftArm.rotation.x = 0;
+      player.userData.rightArm.rotation.x = 0;
+    }
 
     camera.position.set(player.position.x, player.position.y + 10, player.position.z + 20);
     camera.lookAt(player.position);


### PR DESCRIPTION
## Summary
- replace red cube with simple 2-head chibi character built from basic geometries
- animate arms and legs to swing while moving for a walking motion

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbeb9d000833290607e2f0b39fd62