### PR TITLE
Preserve facing direction during vertical movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,9 @@
     jumpMove.z += padDir.z;
     if (jumpMove.lengthSq() > 0) {
       jumpMove.normalize().multiplyScalar(speed);
-      facingRight = jumpMove.x >= 0;
+      if (jumpMove.x !== 0) {
+        facingRight = jumpMove.x > 0;
+      }
     }
   }
 
@@ -445,7 +447,9 @@
       player.position.z += move.z * speed;
       player.position.x = THREE.MathUtils.clamp(player.position.x, -HALF_MAP, HALF_MAP);
       player.position.z = THREE.MathUtils.clamp(player.position.z, -HALF_MAP, HALF_MAP);
-      facingRight = move.x >= 0;
+      if (move.x !== 0) {
+        facingRight = move.x > 0;
+      }
 
       walkOffset += 0.2;
       const angle = Math.sin(walkOffset) * 0.5;


### PR DESCRIPTION
## Summary
- keep existing facing sprite when moving vertically
- update facing direction only when horizontal input occurs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5b1c18dc833290072528e75f938a