### PR TITLE
fix: block traversal through steep terrain

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,7 +496,8 @@
       const currY = getHeight(player.position.x, player.position.z) + 0.5;
       const nextY = getHeight(nextX, nextZ) + 0.5;
 
-      if (nextY - currY <= MAX_STEP) {
+      const heightDiff = nextY - currY;
+      if (Math.abs(heightDiff) <= MAX_STEP) {
         player.position.x = nextX;
         player.position.z = nextZ;
         player.position.y = nextY;


### PR DESCRIPTION
## Summary
- prevent movement when the height difference exceeds the allowed step both up and down

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689cb6f360c48332a69c1d03d467fcac