### PR TITLE
Fix terrain height mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,8 @@
   const pos = groundGeometry.attributes.position;
   for (let i = 0; i < pos.count; i++) {
     const x = pos.getX(i);
-    const z = pos.getY(i);
+    // Y coordinates become Z after the ground is rotated, so flip to get world Z
+    const z = -pos.getY(i);
     const y = getHeight(x, z);
     pos.setZ(i, y);
   }


### PR DESCRIPTION
## Summary
- Correct terrain height mapping by flipping coordinates before computing height

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d3a8712e08332832935a65eed8994