### PR TITLE
Ensure buildings block player's limbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
   const WALL_THICKNESS = 1;
   const BOUNDARY_MIN = -HALF_MAP + WALL_THICKNESS / 2;
   const BOUNDARY_MAX = HALF_MAP - WALL_THICKNESS / 2;
+  const PLAYER_RADIUS = 0.6;
 
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x87ceeb);
@@ -172,8 +173,9 @@
   const colliders = [];
 
   function isColliding(pos) {
+    const playerSphere = new THREE.Sphere(pos, PLAYER_RADIUS);
     for (const box of colliders) {
-      if (box.containsPoint(pos)) return true;
+      if (box.intersectsSphere(playerSphere)) return true;
     }
     return false;
   }


### PR DESCRIPTION
## Summary
- Use a bounding sphere to detect collisions so buildings block player arms and legs.
- Added PLAYER_RADIUS constant for expanded collision checks.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de19073ac83329b1cdad58b22a939