### PR TITLE
feat: add inventory, status, and level systems

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,80 @@
       display: block;
       margin-bottom: 5px;
     }
+    .ui-button{
+      position:absolute;
+      top:20px;
+      left:20px;
+      background:rgba(0,0,0,0.5);
+      color:#fff;
+      padding:5px 10px;
+      border-radius:5px;
+      cursor:pointer;
+      user-select:none;
+    }
+    #statusToggle{left:120px;}
+    .panel{
+      position:absolute;
+      top:60px;
+      left:20px;
+      background:rgba(255,255,255,0.9);
+      padding:10px;
+      border-radius:8px;
+      display:none;
+      max-height:80vh;
+      overflow-y:auto;
+    }
+    #inventoryPanel{width:300px;}
+    .tabs{display:flex;margin-bottom:5px;}
+    .tabs button{flex:1;padding:5px;cursor:pointer;}
+    .tab-content{
+      display:none;
+      grid-template-columns:repeat(4,1fr);
+      gap:4px;
+      max-height:320px;
+      overflow-y:auto;
+    }
+    .tab-content.active{display:grid;}
+    .slot{width:60px;height:60px;border:1px solid #333;}
+    #statusPanel .stat{margin-bottom:5px;}
+    #hpBar,#mpBar{
+      width:100%;
+      height:10px;
+      background:#555;
+      border-radius:5px;
+      overflow:hidden;
+      margin-bottom:5px;
+    }
+    #hpBar div{height:100%;background:red;width:100%;}
+    #mpBar div{height:100%;background:blue;width:100%;}
   </style>
 </head>
 <body>
+<div id="inventoryToggle" class="ui-button">INV</div>
+<div id="statusToggle" class="ui-button">STAT</div>
+<div id="inventoryPanel" class="panel">
+  <div class="tabs">
+    <button data-tab="equipment">장비</button>
+    <button data-tab="consumables">소비</button>
+    <button data-tab="etc">기타</button>
+  </div>
+  <div id="equipmentTab" class="tab-content"></div>
+  <div id="consumablesTab" class="tab-content"></div>
+  <div id="etcTab" class="tab-content"></div>
+</div>
+<div id="statusPanel" class="panel">
+  <div class="stat">레벨: <span id="levelValue"></span></div>
+  <div class="stat">HP: <span id="hpValue"></span></div>
+  <div id="hpBar"><div id="hpFill"></div></div>
+  <div class="stat">MP: <span id="mpValue"></span></div>
+  <div id="mpBar"><div id="mpFill"></div></div>
+  <div class="stat">힘: <span id="strValue"></span></div>
+  <div class="stat">민첩: <span id="agiValue"></span></div>
+  <div class="stat">지력: <span id="intValue"></span></div>
+  <div class="stat">행운: <span id="lukValue"></span></div>
+  <div class="stat">물리공격력: <span id="physAtkValue"></span></div>
+  <div class="stat">마법공격력: <span id="magAtkValue"></span></div>
+</div>
 <div id="joystick"></div>
 <div id="jumpButton">JUMP</div>
 <div id="attackButton">ATK</div>
@@ -109,6 +180,47 @@
   const BOUNDARY_MAX = HALF_MAP - WALL_THICKNESS / 2;
   const PLAYER_RADIUS = 0.6;
 
+  const stats = {
+    level: 1,
+    str: 10,
+    agi: 10,
+    int: 10,
+    luk: 10,
+    physAtk: 100,
+    magAtk: 100,
+    hp: 0,
+    mp: 0,
+    maxHP: 0,
+    maxMP: 0
+  };
+
+  function recalcStats() {
+    stats.maxHP = 100 + (stats.level - 1) * Math.floor(10 + stats.str * 5);
+    stats.maxMP = 50 + (stats.level - 1) * Math.floor(5 + stats.int * 5);
+    if (stats.hp === 0) stats.hp = stats.maxHP;
+    if (stats.mp === 0) stats.mp = stats.maxMP;
+    stats.hp = Math.min(stats.hp, stats.maxHP);
+    stats.mp = Math.min(stats.mp, stats.maxMP);
+  }
+
+  function levelUp() {
+    stats.level++;
+    recalcStats();
+    updateStatusUI();
+  }
+
+  function calcPhysicalDamage(mainStat, subStat, coeff = 1) {
+    const base = ((mainStat * 4) + subStat) * stats.physAtk / 100;
+    return Math.floor(base * coeff);
+  }
+
+  function calcMagicDamage(mainStat, subStat, coeff = 1) {
+    const base = (mainStat + subStat * 0.5) * stats.magAtk / 100;
+    return Math.floor(base * coeff);
+  }
+
+  recalcStats();
+
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x87ceeb);
 
@@ -117,6 +229,57 @@
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
+
+  const inventoryToggle = document.getElementById('inventoryToggle');
+  const statusToggle = document.getElementById('statusToggle');
+  const inventoryPanel = document.getElementById('inventoryPanel');
+  const statusPanel = document.getElementById('statusPanel');
+  const equipmentTab = document.getElementById('equipmentTab');
+  const consumablesTab = document.getElementById('consumablesTab');
+  const etcTab = document.getElementById('etcTab');
+
+  function createSlots(container) {
+    for (let i = 0; i < 32; i++) {
+      const slot = document.createElement('div');
+      slot.className = 'slot';
+      container.appendChild(slot);
+    }
+  }
+  [equipmentTab, consumablesTab, etcTab].forEach(createSlots);
+
+  function showTab(name) {
+    [equipmentTab, consumablesTab, etcTab].forEach(div => div.classList.remove('active'));
+    document.getElementById(name + 'Tab').classList.add('active');
+  }
+  showTab('equipment');
+
+  inventoryPanel.querySelectorAll('.tabs button').forEach(btn => {
+    btn.addEventListener('click', () => showTab(btn.dataset.tab));
+  });
+
+  function toggleInventory() {
+    inventoryPanel.style.display = inventoryPanel.style.display === 'block' ? 'none' : 'block';
+  }
+  function toggleStatus() {
+    statusPanel.style.display = statusPanel.style.display === 'block' ? 'none' : 'block';
+  }
+  inventoryToggle.addEventListener('click', toggleInventory);
+  statusToggle.addEventListener('click', toggleStatus);
+
+  function updateStatusUI() {
+    document.getElementById('levelValue').textContent = stats.level;
+    document.getElementById('hpValue').textContent = `${stats.hp}/${stats.maxHP}`;
+    document.getElementById('mpValue').textContent = `${stats.mp}/${stats.maxMP}`;
+    document.getElementById('strValue').textContent = stats.str;
+    document.getElementById('agiValue').textContent = stats.agi;
+    document.getElementById('intValue').textContent = stats.int;
+    document.getElementById('lukValue').textContent = stats.luk;
+    document.getElementById('physAtkValue').textContent = stats.physAtk;
+    document.getElementById('magAtkValue').textContent = stats.magAtk;
+    document.getElementById('hpFill').style.width = (stats.hp / stats.maxHP * 100) + '%';
+    document.getElementById('mpFill').style.width = (stats.mp / stats.maxMP * 100) + '%';
+  }
+  updateStatusUI();
 
   // Lighting for shaded terrain
   const light = new THREE.DirectionalLight(0xffffff, 1);
@@ -387,6 +550,9 @@
     const key = e.key.toLowerCase();
     keys[key] = true;
     if (key === ' ') startJump();
+    if (key === 'i') toggleInventory();
+    if (key === 'p') toggleStatus();
+    if (key === 'l') levelUp();
   });
   document.addEventListener('keyup', (e) => { keys[e.key.toLowerCase()] = false; });
 


### PR DESCRIPTION
## Summary
- add inventory and status panels with tabs and grid layout
- implement level-based HP/MP and damage formulas
- enable keyboard and button toggles for inventory and status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689deeb2dcd88332b2ca79d1df046507