### PR TITLE
feat: add equipment slot icons and body layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,12 +123,48 @@
       overflow-y:auto;
     }
     .tab-content.active{display:grid;}
-    .slot{width:60px;height:60px;border:1px solid #333;}
+    .slot{
+      width:60px;
+      height:60px;
+      border:1px solid #333;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-size:32px;
+    }
     #equipmentPanel{
       display:grid;
-      grid-template-columns:repeat(4,60px);
+      grid-template-columns:repeat(3,60px);
+      grid-template-rows:repeat(5,60px);
       gap:4px;
+      justify-content:center;
     }
+    .slot[data-slot="ear1"]{grid-row:1;grid-column:1;}
+    .slot[data-slot="hat"]{grid-row:1;grid-column:2;}
+    .slot[data-slot="ear2"]{grid-row:1;grid-column:3;}
+    .slot[data-slot="ring1"]{grid-row:2;grid-column:1;}
+    .slot[data-slot="top"]{grid-row:2;grid-column:2;}
+    .slot[data-slot="ring2"]{grid-row:2;grid-column:3;}
+    .slot[data-slot="shoulder"]{grid-row:3;grid-column:1;}
+    .slot[data-slot="gloves"]{grid-row:3;grid-column:2;}
+    .slot[data-slot="cape"]{grid-row:3;grid-column:3;}
+    .slot[data-slot="belt"]{grid-row:4;grid-column:1;}
+    .slot[data-slot="bottom"]{grid-row:4;grid-column:2;}
+    .slot[data-slot="pet"]{grid-row:4;grid-column:3;}
+    .slot[data-slot="shoes"]{grid-row:5;grid-column:2;}
+    .slot[data-slot="hat"]::before{content:'🎩';}
+    .slot[data-slot="top"]::before{content:'👕';}
+    .slot[data-slot="bottom"]::before{content:'👖';}
+    .slot[data-slot="shoes"]::before{content:'👟';}
+    .slot[data-slot="gloves"]::before{content:'🧤';}
+    .slot[data-slot="cape"]::before{content:'🦺';}
+    .slot[data-slot="belt"]::before{content:'🧷';}
+    .slot[data-slot="shoulder"]::before{content:'🛡️';}
+    .slot[data-slot="ear1"]::before{content:'👂';}
+    .slot[data-slot="ear2"]::before{content:'👂';}
+    .slot[data-slot="ring1"]::before{content:'💍';}
+    .slot[data-slot="ring2"]::before{content:'💍';}
+    .slot[data-slot="pet"]::before{content:'🐶';}
     #statusPanel .stat{margin-bottom:5px;}
     #hpBar,#mpBar{
       width:100%;


### PR DESCRIPTION
## Summary
- display emoji icons in equipment slots to visually represent each gear type
- rearrange equipment panel into a body-shaped grid for intuitive slot placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2d223dfc83328fb5607f13a8eb52