### PR TITLE
Fix sword swing orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,6 +780,7 @@
       new THREE.RingGeometry(0.3, 0.8, 32, 1, Math.PI / 2, Math.PI / 2),
       new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.8, side: THREE.DoubleSide })
     );
+    arc.rotation.order = 'YXZ';
     arc.position.copy(player.position);
     arc.position.y += 0.5;
     const angle = Math.atan2(target.position.x - player.position.x, target.position.z - player.position.z);


### PR DESCRIPTION
## Summary
- Ensure sword swings always stay horizontal by adjusting slash arc rotation order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1919e8a8083328c5434434fc8f5ab