### PR TITLE
Improve sword attack detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@
   let attackHeld = false;
 
   const weaponConfig = {
-    sword: { detect: 3, range: 1.5 },
+    sword: { detect: 2.5, range: 2.5 },
     bow: { detect: 10, speed: 0.3, radius: 0.1 },
     staff: { detect: 8 }
   };
@@ -897,7 +897,8 @@
   function startAttack() {
     if (attacking) return;
     const cfg = weaponConfig[currentWeapon];
-    const target = getNearestMonster(cfg.detect);
+    const detectRange = cfg.range || cfg.detect;
+    const target = getNearestMonster(detectRange);
     if (!target) return;
     attacking = true;
     if (currentWeapon === 'sword') {


### PR DESCRIPTION
## Summary
- Widen sword attack range to 2.5 units
- Use sword range for target detection to only attack within swing reach

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b6826adc8332bf2d1bef7668351b