### PR TITLE
Align sword detection with swing range

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,7 +778,7 @@
   function swingSword(target) {
     const range = weaponConfig.sword.range;
     const arc = new THREE.Mesh(
-      new THREE.RingGeometry(range * 0.12, range * 0.32, 32, 1, Math.PI / 2, Math.PI / 2),
+      new THREE.RingGeometry(range * 0.8, range, 32, 1, Math.PI / 2, Math.PI / 2),
       new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.8, side: THREE.DoubleSide })
     );
     arc.rotation.order = 'YXZ';


### PR DESCRIPTION
## Summary
- Match sword swing geometry to weapon range so detection doesn't exceed attack reach

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2100f556c8332b9b8f65653e126b1