### PR TITLE
feat: add basic monster AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,14 +671,25 @@
 
   const monsters = [];
   const MONSTER_RADIUS = 0.3;
+  const MONSTER_DETECT_RANGE = 5;
+  const MONSTER_SPEED = 0.02;
+  const MONSTER_ATTACK_DELAY = 1000; // ms
+  const MONSTER_ATTACK_RANGE = MONSTER_RADIUS + PLAYER_RADIUS;
+
   function spawnMonster(x, z, hp = 1) {
     const m = new THREE.Mesh(
       new THREE.BoxGeometry(0.6, 0.6, 0.6),
       new THREE.MeshBasicMaterial({ color: 0xff0000 })
     );
     m.position.set(x, getGroundHeight(x, z) + 0.3, z);
-    m.userData.hp = hp;
-    m.userData.radius = MONSTER_RADIUS;
+    m.userData = {
+      hp,
+      radius: MONSTER_RADIUS,
+      spawn: m.position.clone(),
+      wanderDir: new THREE.Vector3(),
+      wanderTime: 0,
+      lastAttack: 0
+    };
     scene.add(m);
     monsters.push(m);
   }
@@ -1015,6 +1026,65 @@
       player.userData.leftArm.rotation.x = 0;
       if (!attacking) player.userData.rightArm.rotation.x = 0;
       player.position.y = getGroundHeight(player.position.x, player.position.z) + 0.5;
+    }
+    for (const m of monsters) {
+      const dist = player.position.distanceTo(m.position);
+      const now = performance.now();
+      if (dist < MONSTER_DETECT_RANGE) {
+        const dir = new THREE.Vector3().subVectors(player.position, m.position);
+        dir.y = 0;
+        if (dir.lengthSq() > 0) {
+          dir.normalize();
+          const nextX = THREE.MathUtils.clamp(m.position.x + dir.x * MONSTER_SPEED, BOUNDARY_MIN, BOUNDARY_MAX);
+          const nextZ = THREE.MathUtils.clamp(m.position.z + dir.z * MONSTER_SPEED, BOUNDARY_MIN, BOUNDARY_MAX);
+          const nextPos = new THREE.Vector3(nextX, m.position.y, nextZ);
+          if (!isColliding(nextPos, MONSTER_RADIUS)) {
+            m.position.x = nextX;
+            m.position.z = nextZ;
+            m.position.y = getGroundHeight(nextX, nextZ) + MONSTER_RADIUS;
+          }
+        }
+        if (dist < MONSTER_ATTACK_RANGE && now - m.userData.lastAttack > MONSTER_ATTACK_DELAY) {
+          stats.hp = Math.max(0, stats.hp - 10);
+          updateStatusUI();
+          m.userData.lastAttack = now;
+        }
+      } else {
+        const homeDist = m.position.distanceTo(m.userData.spawn);
+        if (homeDist > 0.1) {
+          const dir = new THREE.Vector3().subVectors(m.userData.spawn, m.position);
+          dir.y = 0;
+          if (dir.lengthSq() > 0) {
+            dir.normalize();
+            const nextX = THREE.MathUtils.clamp(m.position.x + dir.x * MONSTER_SPEED, BOUNDARY_MIN, BOUNDARY_MAX);
+            const nextZ = THREE.MathUtils.clamp(m.position.z + dir.z * MONSTER_SPEED, BOUNDARY_MIN, BOUNDARY_MAX);
+            const nextPos = new THREE.Vector3(nextX, m.position.y, nextZ);
+            if (!isColliding(nextPos, MONSTER_RADIUS)) {
+              m.position.x = nextX;
+              m.position.z = nextZ;
+              m.position.y = getGroundHeight(nextX, nextZ) + MONSTER_RADIUS;
+            }
+          }
+        } else {
+          if (m.userData.wanderTime <= 0) {
+            if (Math.random() < 0.01) {
+              const angle = Math.random() * Math.PI * 2;
+              m.userData.wanderDir.set(Math.cos(angle), 0, Math.sin(angle));
+              m.userData.wanderTime = 60;
+            }
+          } else {
+            const nextX = THREE.MathUtils.clamp(m.position.x + m.userData.wanderDir.x * MONSTER_SPEED, BOUNDARY_MIN, BOUNDARY_MAX);
+            const nextZ = THREE.MathUtils.clamp(m.position.z + m.userData.wanderDir.z * MONSTER_SPEED, BOUNDARY_MIN, BOUNDARY_MAX);
+            const nextPos = new THREE.Vector3(nextX, m.position.y, nextZ);
+            if (!isColliding(nextPos, MONSTER_RADIUS)) {
+              m.position.x = nextX;
+              m.position.z = nextZ;
+              m.position.y = getGroundHeight(nextX, nextZ) + MONSTER_RADIUS;
+            }
+            m.userData.wanderTime--;
+          }
+        }
+      }
     }
 
     for (let i = projectiles.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary
- make red box monsters aware of nearby players
- chase and damage player with 1s attack delay
- wander around spawn when idle

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d01f6eac83328c14d9c7543806ee