### PR TITLE
feat: bring camera closer and add death mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,12 +99,29 @@
       cursor:pointer;
       user-select:none;
     }
-    #statusToggle{left:120px;}
-    #equipmentToggle{left:220px;}
-    #weaponSword{left:320px;}
-    #weaponBow{left:420px;}
-    #weaponStaff{left:520px;}
-    #fullscreenToggle{left:620px;}
+    #inventoryToggle{left:140px;}
+    #statusToggle{left:240px;}
+    #equipmentToggle{left:340px;}
+    #fullscreenToggle{left:440px;}
+    #hud{
+      position:absolute;
+      top:20px;
+      left:20px;
+      width:100px;
+    }
+    #reviveDialog{
+      position:absolute;
+      top:50%;
+      left:50%;
+      transform:translate(-50%,-50%);
+      background:rgba(0,0,0,0.7);
+      color:#fff;
+      padding:20px;
+      border-radius:10px;
+      display:none;
+      text-align:center;
+    }
+    #reviveDialog button{margin-top:10px;}
     .panel{
       position:absolute;
       top:60px;
@@ -201,13 +218,18 @@
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 </head>
 <body>
+<div id="hud">
+  <div id="hpBar"><div id="hpFill"></div></div>
+  <div id="mpBar"><div id="mpFill"></div></div>
+</div>
 <div id="inventoryToggle" class="ui-button">INV</div>
 <div id="statusToggle" class="ui-button">STAT</div>
 <div id="equipmentToggle" class="ui-button">EQUIP</div>
-<div id="weaponSword" class="ui-button">SWD</div>
-<div id="weaponBow" class="ui-button">BOW</div>
-<div id="weaponStaff" class="ui-button">STF</div>
 <div id="fullscreenToggle" class="ui-button">FULL</div>
+<div id="reviveDialog">
+  <div>비석이 떨어지면 마을에서 부활합니다.</div>
+  <button id="reviveConfirm">확인</button>
+</div>
 <div id="inventoryPanel" class="panel">
   <div id="inventoryGrid">
     <div class="tabs">
@@ -224,9 +246,7 @@
 <div id="statusPanel" class="panel">
   <div class="stat">레벨: <span id="levelValue"></span></div>
   <div class="stat">HP: <span id="hpValue"></span></div>
-  <div id="hpBar"><div id="hpFill"></div></div>
   <div class="stat">MP: <span id="mpValue"></span></div>
-  <div id="mpBar"><div id="mpFill"></div></div>
   <div class="stat">힘: <span id="strValue"></span></div>
   <div class="stat">민첩: <span id="agiValue"></span></div>
   <div class="stat">지력: <span id="intValue"></span></div>
@@ -738,11 +758,10 @@
     ctx.fill();
     ctx.stroke();
   }
-
+  const TOWN_POS = new THREE.Vector3(0, getGroundHeight(0, 0) + 0.5, 0);
   const player = createPlayer();
-  player.position.set(0, getGroundHeight(0, 0) + 0.5, 0);
+  player.position.copy(TOWN_POS);
   scene.add(player);
-
   scene.add(createShop('잡화상점', 0xffaa00, -5, -5, drawPotionIcon));
   scene.add(createShop('장비상점', 0x00aaff, 5, -5, drawWeaponIcon));
 
@@ -774,7 +793,7 @@
   spawnMonster(10, 10, Infinity);
 
 
-  camera.position.set(0, 10, 20);
+  camera.position.set(0, 5, 10);
   camera.lookAt(player.position);
 
   let speed = 0.05;
@@ -817,12 +836,14 @@
   let padActive = false;
   const jumpButton = document.getElementById('jumpButton');
   const attackButton = document.getElementById('attackButton');
-  const weaponSword = document.getElementById('weaponSword');
-  const weaponBow = document.getElementById('weaponBow');
-  const weaponStaff = document.getElementById('weaponStaff');
+  const reviveDialog = document.getElementById('reviveDialog');
+  const reviveConfirm = document.getElementById('reviveConfirm');
   let jumpHeld = false;
   let attacking = false;
   let attackHeld = false;
+  let dead = false;
+  let tombstone = null;
+  let tombstoneLanded = false;
 
   const weaponConfig = {
     sword: { detect: 3, range: 1.5, cooldown: 0, lastAttack: 0 },
@@ -839,9 +860,19 @@
   }
   setWeapon('sword');
 
-  weaponSword.addEventListener('click', () => setWeapon('sword'));
-  weaponBow.addEventListener('click', () => setWeapon('bow'));
-  weaponStaff.addEventListener('click', () => setWeapon('staff'));
+  reviveConfirm.addEventListener('click', () => {
+    reviveDialog.style.display = 'none';
+    if (tombstone) {
+      scene.remove(tombstone);
+      tombstone = null;
+    }
+    stats.hp = Math.floor(stats.maxHP * 0.1);
+    stats.mp = Math.floor(stats.maxMP * 0.1);
+    updateStatusUI();
+    player.position.copy(TOWN_POS);
+    dead = false;
+    tombstoneLanded = false;
+  });
 
   function getNearestMonster(range) {
     let nearest = null;
@@ -864,6 +895,19 @@
       const idx = monsters.indexOf(monster);
       if (idx >= 0) monsters.splice(idx, 1);
     }
+  }
+
+  function handleDeath() {
+    if (dead) return;
+    dead = true;
+    attackHeld = false;
+    jumpHeld = false;
+    const geom = new THREE.BoxGeometry(1, 2, 0.5);
+    const mat = new THREE.MeshBasicMaterial({ color: 0x808080 });
+    tombstone = new THREE.Mesh(geom, mat);
+    tombstone.position.set(player.position.x, player.position.y + 10, player.position.z);
+    scene.add(tombstone);
+    tombstoneLanded = false;
   }
 
   function swingSword(target) {
@@ -1033,6 +1077,23 @@
   let facingRight = true;
 
   function update() {
+    if (dead) {
+      if (tombstone) {
+        tombstone.position.y -= 0.2;
+        const ground = getGroundHeight(tombstone.position.x, tombstone.position.z) + 1;
+        if (tombstone.position.y <= ground) {
+          tombstone.position.y = ground;
+          if (!tombstoneLanded) {
+            tombstoneLanded = true;
+            reviveDialog.style.display = 'block';
+          }
+        }
+      }
+      player.position.y = getGroundHeight(player.position.x, player.position.z) + 0.5;
+      camera.position.set(player.position.x, player.position.y + 5, player.position.z + 10);
+      camera.lookAt(player.position);
+      return;
+    }
     if (attackHeld && !attacking) startAttack();
     if (!isJumping && jumpHeld) startJump();
     const move = new THREE.Vector3();
@@ -1111,7 +1172,7 @@
     for (const m of monsters) {
       const dist = player.position.distanceTo(m.position);
       const now = performance.now();
-      if (dist < MONSTER_DETECT_RANGE) {
+      if (!dead && dist < MONSTER_DETECT_RANGE) {
         const dir = new THREE.Vector3().subVectors(player.position, m.position);
         dir.y = 0;
         if (dir.lengthSq() > 0) {
@@ -1128,6 +1189,7 @@
         if (dist < MONSTER_ATTACK_RANGE && now - m.userData.lastAttack > MONSTER_ATTACK_DELAY) {
           stats.hp = Math.max(0, stats.hp - 10);
           updateStatusUI();
+          if (stats.hp === 0) handleDeath();
           m.userData.lastAttack = now;
         }
       } else {
@@ -1190,7 +1252,7 @@
 
     player.rotation.y = facingRight ? Math.PI / 3 : -Math.PI / 3;
 
-    camera.position.set(player.position.x, player.position.y + 10, player.position.z + 20);
+    camera.position.set(player.position.x, player.position.y + 5, player.position.z + 10);
     camera.lookAt(player.position);
   }
 


### PR DESCRIPTION
## Summary
- reposition HUD with HP/MP bars at top-left and remove weapon buttons
- bring camera closer to player for tighter view
- implement ghost/death state with tombstone drop and town revival

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afaa5184ec833288bdb1f71609c874